### PR TITLE
fix fail on `-setwebproxystate Wi-Fi off`

### DIFF
--- a/proxysetup.c
+++ b/proxysetup.c
@@ -78,7 +78,8 @@ int main (int argc, char **argv)
         }
         cmd[c++] = '"';
     }
-    *cmd ++ = '\0';
+    // *cmd ++ = '\0';
+    cmd[c++] = '\0';
 
     // Set ourselves as root
     setuid(0);


### PR DESCRIPTION
The `cmd` variable malloc length + 1 size space without initialization, but the '\0' char is at the position length + 2, postion length + 1 is a random value.
This cause `-setwebproxystate Wi-Fi off` command execute with a correct return (value 0), but nothing happend (proxy state is still on).